### PR TITLE
Win32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,15 @@
 
 # for debugging
 # CFLAGS += -ggdb
+#-l : 
 LDFLAGS += -lrt
+W32_LDFLAGS += 
 
 rtl_868: ws300.o transmission.o nrz_decode.o main.o logging.o tx29.o tools.o data_logger.o
 	${CC} ${LDFLAGS} $^ -o $@
+
+rtl_868.exe: ws300.o transmission.o nrz_decode.o main.o logging.o tx29.o tools.o data_logger.o
+	${CC} ${W32_LDFLAGS} $^ -o $@
 
 %.lss: %
 	objdump -xS $< > $@

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Reciever software for FM modulated temperature stations.
 compile: 'make'
 run: rtl_fm -f 868.26e6 -M fm -s 500k -r 75k -g 42 -A fast | ./rtl_868 > dump-file.txt
 
+Win32 Cross compilation (build on Linuw, run on Windows)
+compile: './wmake.sh rtl_868.exe'
+

--- a/data_logger.c
+++ b/data_logger.c
@@ -20,6 +20,7 @@
 
 #include "logging.h"
 #include "data_logger.h"
+#include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
 

--- a/main.c
+++ b/main.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <fcntl.h>
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #include "os/windows.h"
@@ -176,7 +177,9 @@ int main (int argc, char **argv) {
     }
     return 1;
   }
-
+#if defined(__MINGW32__) || defined(__MINGW64__)
+  setmode(fileno(in), O_BINARY);
+#endif
   if ((outfilename == 0) || (strcmp( outfilename, "-" ) == 0))
     out = stdout;
   else
@@ -189,6 +192,9 @@ int main (int argc, char **argv) {
     }
     return 1;
   }
+#if defined(__MINGW32__) || defined(__MINGW64__)
+  setmode(fileno(out), O_BINARY);
+#endif
 
   stream_decoder_t mysd = { .init = 0, .input = &duplicate_stream_input };
   
@@ -222,10 +228,13 @@ int main (int argc, char **argv) {
   while (1) {
     /* read a chunk */
     int n = fread( d, sizeof(d[0]), sizeof(d)/sizeof(d[0]), in );
-
-    if (n == 0) {
+    if (feof(in)) {
       logging_error( "\nEOF reached at %i.\n", ndata );
       break;
+    }
+    if (n == 0) {
+      logging_error( "\n0 data readed at %i.\n", ndata );
+      continue;
     } else {
       ndata += n;
     }

--- a/main.c
+++ b/main.c
@@ -183,7 +183,7 @@ int main (int argc, char **argv) {
   if ((outfilename == 0) || (strcmp( outfilename, "-" ) == 0))
     out = stdout;
   else
-    out = fopen( outfilename, "ab" );
+    out = fopen( outfilename, "a" );
   if (out == 0) {
     if (outfilename == 0) {
       logging_error( "Could not open stdout as output file.\n" );
@@ -192,9 +192,7 @@ int main (int argc, char **argv) {
     }
     return 1;
   }
-#if defined(__MINGW32__) || defined(__MINGW64__)
-  setmode(fileno(out), O_BINARY);
-#endif
+
 
   stream_decoder_t mysd = { .init = 0, .input = &duplicate_stream_input };
   
@@ -218,7 +216,7 @@ int main (int argc, char **argv) {
   last_status.tv_sec = time(NULL);
   last_status.tv_nsec = 0;
 #elif defined(__MINGW32__) || defined(__MINGW64__)
-    last_status.tv_sec = time(NULL);
+  last_status.tv_sec = time(NULL);
   last_status.tv_nsec = 0;
 #else
   clock_gettime( CLOCK_MONOTONIC, &last_status );
@@ -244,10 +242,10 @@ int main (int argc, char **argv) {
     now.tv_sec = time(NULL);
     now.tv_nsec = 0;
 #elif defined(__MINGW32__) || defined(__MINGW64__)
-    last_status.tv_sec = time(NULL);
-  last_status.tv_nsec = 0;
+    now.tv_sec = time(NULL);
+    now.tv_nsec = 0;
 #else
-  clock_gettime( CLOCK_MONOTONIC, &now );
+    clock_gettime( CLOCK_MONOTONIC, &now );
 #endif
     // if time is over, redisplay status
     float dt = 1.0 * (now.tv_sec - last_status.tv_sec) + 1.0 * (now.tv_nsec - last_status.tv_nsec) / 1e9;
@@ -263,9 +261,12 @@ int main (int argc, char **argv) {
       char tp_e;
       float tp_b;
       data_to_string( throughput, &tp_b, &tp_e );
-      logging_status( 0, "%s -> %s, %1.1f%c, %1.1f%c", filename, outfilename, nd_b, nd_e, tp_b, tp_e );
-    
-      logging_restatus();
+	  	
+		if (verbose > 1) {
+			logging_status( 0, "%s -> %s, %1.1f%c, %1.1f%c", filename, outfilename, nd_b, nd_e, tp_b, tp_e );
+			logging_restatus();
+		}
+	  
       last_status.tv_sec = now.tv_sec;
       last_status.tv_nsec = now.tv_nsec;
     }

--- a/main.c
+++ b/main.c
@@ -37,6 +37,9 @@
 #include <ctype.h>
 #include <time.h>
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include "os/windows.h"
+#endif
 int data_to_string( float data, float* base, char* cexp ) {
   // convert the value of data to base + exponent notation
   int exp = 0;
@@ -208,6 +211,8 @@ int main (int argc, char **argv) {
 #ifdef __APPLE__
   last_status.tv_sec = time(NULL);
   last_status.tv_nsec = 0;
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  clock_gettime_w32(0, &last_status);
 #else
   clock_gettime( CLOCK_MONOTONIC, &last_status );
 #endif
@@ -227,8 +232,10 @@ int main (int argc, char **argv) {
 #ifdef __APPLE__
     now.tv_sec = time(NULL);
     now.tv_nsec = 0;
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  clock_gettime_w32(0, &now);
 #else
-    clock_gettime( CLOCK_MONOTONIC, &now );
+  clock_gettime( CLOCK_MONOTONIC, &now );
 #endif
     // if time is over, redisplay status
     float dt = 1.0 * (now.tv_sec - last_status.tv_sec) + 1.0 * (now.tv_nsec - last_status.tv_nsec) / 1e9;

--- a/main.c
+++ b/main.c
@@ -167,7 +167,7 @@ int main (int argc, char **argv) {
   if ((filename == 0) || (strcmp( filename, "-" ) == 0))
     in = stdin;
   else
-    in = fopen( filename, "r" );
+    in = fopen( filename, "rb" );
   if (in == 0) {
     if (filename == 0) {
       logging_error( "Could not open stdin as input file.\n" );
@@ -180,7 +180,7 @@ int main (int argc, char **argv) {
   if ((outfilename == 0) || (strcmp( outfilename, "-" ) == 0))
     out = stdout;
   else
-    out = fopen( outfilename, "a" );
+    out = fopen( outfilename, "ab" );
   if (out == 0) {
     if (outfilename == 0) {
       logging_error( "Could not open stdout as output file.\n" );
@@ -212,7 +212,8 @@ int main (int argc, char **argv) {
   last_status.tv_sec = time(NULL);
   last_status.tv_nsec = 0;
 #elif defined(__MINGW32__) || defined(__MINGW64__)
-  clock_gettime_w32(0, &last_status);
+    last_status.tv_sec = time(NULL);
+  last_status.tv_nsec = 0;
 #else
   clock_gettime( CLOCK_MONOTONIC, &last_status );
 #endif
@@ -221,6 +222,7 @@ int main (int argc, char **argv) {
   while (1) {
     /* read a chunk */
     int n = fread( d, sizeof(d[0]), sizeof(d)/sizeof(d[0]), in );
+
     if (n == 0) {
       logging_error( "\nEOF reached at %i.\n", ndata );
       break;
@@ -233,7 +235,8 @@ int main (int argc, char **argv) {
     now.tv_sec = time(NULL);
     now.tv_nsec = 0;
 #elif defined(__MINGW32__) || defined(__MINGW64__)
-  clock_gettime_w32(0, &now);
+    last_status.tv_sec = time(NULL);
+  last_status.tv_nsec = 0;
 #else
   clock_gettime( CLOCK_MONOTONIC, &now );
 #endif
@@ -264,6 +267,6 @@ int main (int argc, char **argv) {
       td.input( d[i] );
     }
   }
-
+  printf("Program terminated\n");
   fclose(in);
 }

--- a/os/windows.h
+++ b/os/windows.h
@@ -1,0 +1,33 @@
+#include <windows.h>
+
+#define BILLION                             (1E9)
+
+static BOOL g_first_time = 1;
+static LARGE_INTEGER g_counts_per_sec;
+
+// http://stackoverflow.com/a/38212960
+int clock_gettime_w32(int dummy, struct timespec *ct)
+{
+    LARGE_INTEGER count;
+
+    if (g_first_time)
+    {
+        g_first_time = 0;
+
+        if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
+        {
+            g_counts_per_sec.QuadPart = 0;
+        }
+    }
+
+    if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
+            (0 == QueryPerformanceCounter(&count)))
+    {
+        return -1;
+    }
+
+    ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
+    ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
+
+    return 0;
+}

--- a/wmake.sh
+++ b/wmake.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CC=i686-w64-mingw32-gcc-win32
+make $*


### PR DESCRIPTION
Here is a Pullrequest to make rtl_868 compatible with Windows. I finaly succeed to compile it on a Linux box, but with target to Win32. I use the mingw cross compiler, and I can produce a Win32 "rtl_868.exe" file working on Windows Seven (it is a 32 bits exe, I do not know for now how to build a 64 bits exe with MingW).
I modified the Makefile and add a new customized "wmake.sh" script to build for Windows.
There is probably a better/cleaner way to make cross-compilation on this project, but I have to make it quick.

The main difficulties of this port were :
- find Win32 equivalent for structures and functions (mainly related to time.h), and add misssing #include to cover theses functions
- deal with the binary open mode (Window open file in text mode by default)
- verbosity is not very clean on rtl_868 on Windows, probably because of the CMD.exe term shell and the way it handle \r \n .
I will provide builded executable on my blog if the original author of the tool is agree with that.